### PR TITLE
Chores/detail cli helper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["linux", "cpu"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-clap = { version = "4.5.3", features = ["derive"] }
+clap = { version = "4.5.3", features = ["derive", "wrap_help"] }
 itertools = "0.12.1"
 regex = "1.10.3"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -17,7 +17,7 @@ pub fn activate_cmd(args: &OptionalCoresArgs) {
             all_core_nums
         );
     }
-    if args.no_duplicate {
+    if args.no_duplicates {
         let mut core_nums: Vec<_> = core_nums.iter().unique().collect();
     }
     if args.sort {
@@ -35,7 +35,7 @@ pub fn deactivate_cmd(args: &CoresArgs) {
             all_core_nums
         );
     }
-    if args.no_duplicate {
+    if args.no_duplicates {
         let mut core_nums: Vec<_> = core_nums.iter().unique().collect();
     }
     if args.sort {
@@ -56,7 +56,7 @@ pub fn show_cmd(args: &OptionalCoresArgs) {
             all_core_nums
         );
     }
-    if args.no_duplicate {
+    if args.no_duplicates {
         let mut core_nums: Vec<_> = core_nums.iter().unique().collect();
     }
     if args.sort {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,25 +23,61 @@ struct Cli {
 
 #[derive(Args, Debug)]
 struct OptionalCoresArgs {
-    #[arg(short, long, required = false, value_name = "RANGES")]
+    #[arg(
+        short,
+        long,
+        help = "Specify the cores to consider, eg. '2,3-5,11'",
+        required = false,
+        value_name = "RANGES"
+    )]
     cores: Option<String>,
 
-    #[arg(short, long, required = false, action)]
+    #[arg(
+        short,
+        long,
+        help = "Remove duplicates of cores specified with the option '--cores'",
+        required = false,
+        action
+    )]
     no_duplicate: bool,
 
-    #[arg(short, long, required = false, action)]
+    #[arg(
+        short,
+        long,
+        help = "Sort the cores in increasing order",
+        required = false,
+        action
+    )]
     sort: bool,
 }
 
 #[derive(Args, Debug)]
 struct CoresArgs {
-    #[arg(short, long, required = true, value_name = "RANGES")]
+    #[arg(
+        short,
+        long,
+        help = "Specify the cores to consider, eg. '2,3-5,11'",
+        required = true,
+        value_name = "RANGES"
+    )]
     cores: String,
 
-    #[arg(short, long, required = false, action)]
+    #[arg(
+        short,
+        long,
+        help = "Remove duplicates of cores specified with the option '--cores'",
+        required = false,
+        action
+    )]
     no_duplicate: bool,
 
-    #[arg(short, long, required = false, action)]
+    #[arg(
+        short,
+        long,
+        help = "Sort the cores in increasing order",
+        required = false,
+        action
+    )]
     sort: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,13 +33,13 @@ struct OptionalCoresArgs {
     cores: Option<String>,
 
     #[arg(
-        short,
+        short = 'D',
         long,
         help = "Remove duplicates of cores specified with the option '--cores'",
         required = false,
         action
     )]
-    no_duplicate: bool,
+    no_duplicates: bool,
 
     #[arg(
         short,
@@ -63,13 +63,13 @@ struct CoresArgs {
     cores: String,
 
     #[arg(
-        short,
+        short = 'D',
         long,
         help = "Remove duplicates of cores specified with the option '--cores'",
         required = false,
         action
     )]
-    no_duplicate: bool,
+    no_duplicates: bool,
 
     #[arg(
         short,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,14 @@ use clap::{Args, Parser, Subcommand};
 use commands::{activate_cmd, deactivate_cmd, show_cmd};
 
 #[derive(Parser)]
-#[command(version, about, long_about = None)]
+// #[command(version, about, long_about = None)]
+#[command(
+    name = "cpu-cli-controller",
+    version,
+    about = "A program to control/toggle on-off the CPU cores",
+    after_long_help = "Bugs can be reported on GitHub: https://github.com/AlixBernard/cpu-cli-controller/issues",
+    max_term_width = 98
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,15 +81,6 @@ struct CoresArgs {
     sort: bool,
 }
 
-// #[derive(Args, Debug)]
-// struct DisplayArgs {
-//     #[arg(short, long, required = false, action)]
-//     no_duplicate: bool,
-
-//     #[arg(short, long, required = false, action)]
-//     sort: bool,
-// }
-
 #[derive(Subcommand, Debug)]
 enum Commands {
     #[clap(visible_alias = "a")]


### PR DESCRIPTION
Add details in the help section of the CLI tool.

BREAKING CHANGE: the option `--no-duplicate` (`-n`) is changed to `--no-duplicates` (`-D`).